### PR TITLE
Fix branch support

### DIFF
--- a/msk/__main__.py
+++ b/msk/__main__.py
@@ -61,6 +61,7 @@ def main():
         skills_dir=args.skills_dir, repo=SkillRepo(url=args.repo_url, branch=args.repo_branch)
     )
     context.use_token = args.use_token
+    context.branch = context.msm.repo.branch
 
     try:
         return console_actions[args.action](args).perform()

--- a/msk/actions/upgrade.py
+++ b/msk/actions/upgrade.py
@@ -82,5 +82,5 @@ class UpgradeAction(ConsoleAction):
         print('===', title, '===')
         print(body)
         print()
-        pull = create_or_edit_pr(title, body, self.repo.hub, self.user, upgrade_branch)
+        pull = create_or_edit_pr(title, body, self.repo.hub, self.user, upgrade_branch, self.branch)
         print('Created PR at:', pull.html_url)

--- a/msk/actions/upload.py
+++ b/msk/actions/upload.py
@@ -118,7 +118,8 @@ class UploadAction(ConsoleAction):
         pull = create_or_edit_pr(
             title='Add {}'.format(self.entry.name), body=body_template.format(
                 description=description, skill_name=self.entry.name, skill_url=skill_repo.html_url
-            ), user=self.user, branch=branch, skills_repo=self.repo.hub
+            ), user=self.user, branch=branch, skills_repo=self.repo.hub,
+            repo_branch=self.branch
         )
 
         print('Created pull request: ', pull.html_url)

--- a/msk/global_context.py
+++ b/msk/global_context.py
@@ -31,5 +31,6 @@ class GlobalContext:
     lang = Lazy(unset)  # type: str
     msm = Lazy(unset)  # type: MycroftSkillsManager
     use_token = Lazy(unset)  # type: bool
+    branch = Lazy(unset)  # type: str
     github = Lazy(lambda s: ask_for_github_credentials(s.use_token))  # type: Github
     user = Lazy(lambda s: s.github.get_user())  # type: AuthenticatedUser

--- a/msk/repo_action.py
+++ b/msk/repo_action.py
@@ -62,6 +62,7 @@ class SkillData(GlobalContext):
     name = property(lambda self: self.entry.name)
     repo = Lazy(lambda s: RepoData())  # type: RepoData
     repo_git = Lazy(lambda s: Git(join(s.repo.msminfo.path, s.submodule_name)))  # type: Git
+    repo_branch = Lazy(lambda s: s.repo_git.symbolic_ref('refs/remotes/origin/HEAD'))
     git = Lazy(lambda s: Git(s.entry.path))  # type: Git
     hub = Lazy(lambda s: s.github.get_repo(skill_repo_name(s.entry.url)))  # type: Repository
 
@@ -78,8 +79,7 @@ class SkillData(GlobalContext):
         skill_module = self.submodule_name
         self.repo.msminfo.update()
         self.repo_git.fetch()
-        default_branch = self.repo_git.symbolic_ref('refs/remotes/origin/HEAD')
-        self.repo_git.reset(default_branch, hard=True)
+        self.repo_git.reset(self.repo_branch, hard=True)
 
         upgrade_branch = 'upgrade-' + self.name
         self.repo.checkout_branch(upgrade_branch)
@@ -103,8 +103,7 @@ class SkillData(GlobalContext):
 
         # Upgrade skill in case it is outdated
         self.repo_git.fetch()
-        default_branch = self.repo_git.symbolic_ref('refs/remotes/origin/HEAD')
-        self.repo_git.reset(default_branch, hard=True)
+        self.repo_git.reset(self.repo_branch, hard=True)
 
         branch_name = 'add-' + self.name
         self.repo.checkout_branch(branch_name)

--- a/msk/util.py
+++ b/msk/util.py
@@ -149,8 +149,8 @@ def ask_yes_no(message: str, default: Optional[bool]) -> bool:
 
 
 def create_or_edit_pr(title: str, body: str, skills_repo: Repository,
-                      user, branch: str):
-    base = skills_repo.default_branch
+                      user, branch: str, repo_branch: str):
+    base = repo_branch
     head = '{}:{}'.format(user.login, branch)
     pulls = list(skills_repo.get_pulls(base=base, head=head))
     if pulls:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 setup(
     name='msk',
-    version='0.3.10',  # Also update in msk/__init__.py
+    version='0.3.11',  # Also update in msk/__init__.py
     packages=['msk', 'msk.actions'],
     install_requires=['GitPython', 'typing', 'msm>=0.5.13', 'pygithub'],
     url='https://github.com/MycroftAI/mycroft-skills-kit',


### PR DESCRIPTION
Now branches should work via command line like `msm -b 18.08 upload /opt/mycroft/skills/test-skill`.

This also refactors duplicate code used to find the branch of a skill repo.