### PR TITLE
Fix issue with spaces in filenames in add_to_repo

### DIFF
--- a/msk/repo_action.py
+++ b/msk/repo_action.py
@@ -96,8 +96,8 @@ class SkillData(GlobalContext):
 
     def add_to_repo(self) -> str:
         self.repo.msminfo.update()
-        elements = [i.split() for i in self.git.ls_tree('HEAD').split('\n')]
-        existing_mods = [folder for size, typ, sha, folder in elements]
+        existing_mods = [i.split('\t')[1]
+                         for i in self.git.ls_tree('HEAD').split('\n')]
         if self.name not in existing_mods:
             self.repo.git.submodule('add', self.entry.url, self.name)
 


### PR DESCRIPTION
If a filename contained a space the split when parsing ls-tree result produced an extra field. This splits at the tab just before the filename instead of any whitespace.