### PR TITLE
Ensure that git has fullname and email configured

### DIFF
--- a/msk/__main__.py
+++ b/msk/__main__.py
@@ -29,7 +29,7 @@ from msk.actions.create_test import CreateTestAction
 from msk.actions.submit import SubmitAction
 from msk.exceptions import MskException
 from msk.global_context import GlobalContext
-
+from msk.util import ensure_git_user
 action_names = {
     SubmitAction: ['submit', 'update', 'upgrade', 'upload'],
     CreateAction: ['create'],
@@ -44,7 +44,7 @@ def main():
     parser.add_argument('-b', '--repo-branch', help='Branch of skills repo to upload to')
     parser.add_argument('-s', '--skills-dir', help='Directory to look for skills in')
     parser.add_argument('-c', '--repo-cache', help='Location to store local skills repo clone')
-    
+
     subparsers = parser.add_subparsers(dest='action')
     subparsers.required = True
     action_to_cls = {}
@@ -54,6 +54,7 @@ def main():
 
     args = parser.parse_args(sys.argv[1:])
 
+    ensure_git_user()
     context = GlobalContext()
     context.lang = args.lang
     context.msm = MycroftSkillsManager(

--- a/msk/util.py
+++ b/msk/util.py
@@ -80,7 +80,7 @@ def ask_for_github_token() -> Github:
         retry = False
         while True:
             if not retry:
-                print('To auhenticate with GitHub a Personal Access Token is needed.')
+                print('To authenticate with GitHub a Personal Access Token is needed.')
                 print('    1. Go to https://github.com/settings/tokens/new create one')
                 print('    2. Give the token a name like mycroft-msk')
                 print('    3. Select the scopes')
@@ -145,7 +145,7 @@ def store_github_token(token):
         print('Your GitHub Personal Access Token is stored in ' + tokenfile)
         print('')
     else:
-        print('Remember to store your token a safe place.')
+        print('Remember to store your token in a safe place.')
         print('')
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
     version='0.3.14',  # Also update in msk/__init__.py
     packages=['msk', 'msk.actions'],
     package_data={'msk': ['licenses/*']},
-    install_requires=['GitPython', 'typing', 'msm>=0.5.13', 'pygithub', 'requests', 'colorama'],
+    install_requires=['GitPython>=3.0.5', 'typing', 'msm>=0.5.13', 'pygithub',
+                      'requests', 'colorama'],
     url='https://github.com/MycroftAI/mycroft-skills-kit',
     license='Apache-2.0',
     author='Mycroft AI',


### PR DESCRIPTION
Proposed fix for #31. This checks that git is configured before starting any action and will prompt for user full name and user email. The config is stored in the ~/.gitconfig. An alternative may be to not store it but set the `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` environment variables and ask the user to run git --config at a later time.

This can probably be improved allowing to fetch information from github as suggested by @andlo.