### PR TITLE
Update to switch branch correctly

### DIFF
--- a/msk/actions/upgrade.py
+++ b/msk/actions/upgrade.py
@@ -77,7 +77,6 @@ class UpgradeAction(ConsoleAction):
         print('Upgrading an existing skill in the skill repo...')
         upgrade_branch = self.skill.upgrade()
         self.repo.push_to_fork(upgrade_branch)
-
         title, body = self.create_pr_message(self.skill.git, self.skill.hub)
         print()
         print('===', title, '===')

--- a/msk/repo_action.py
+++ b/msk/repo_action.py
@@ -77,6 +77,8 @@ class SkillData(GlobalContext):
 
     def upgrade(self) -> str:
         skill_module = self.submodule_name
+        submod = Git(join(self.repo.msminfo.path, skill_module))
+        submod.remote('set-head', 'origin', '-a')
         self.repo.msminfo.update()
         self.repo_git.fetch()
         self.repo_git.reset(self.repo_branch, hard=True)


### PR DESCRIPTION
This runs "git remote origin -a" to set the local HEAD reference to the
same as the remote. (see "git remote set-head --help")

Could use some additional testing but seems safe as far as I can see.