### PR TITLE
Make the typing dep required for Python 3.4 and lower only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     version='0.3.15',  # Also update in msk/__init__.py
     packages=['msk', 'msk.actions'],
     package_data={'msk': ['licenses/*']},
-    install_requires=['GitPython>=3.0.5', 'typing', 'msm>=0.5.13', 'pygithub',
+    install_requires=['GitPython>=3.0.5', 'msm>=0.5.13', 'pygithub',
                       'requests', 'colorama'],
     url='https://github.com/MycroftAI/mycroft-skills-kit',
     license='Apache-2.0',


### PR DESCRIPTION
Typing is backport for Python older than 3.5, and isn't required on
newer versions