### PR TITLE
remove deprecated intent_file_handler

### DIFF
--- a/msk/actions/create.py
+++ b/msk/actions/create.py
@@ -58,14 +58,14 @@ credits_template = '''## Credits
 {author}
 '''
 
-init_template = '''from mycroft import MycroftSkill, intent_file_handler
+init_template = '''from mycroft import MycroftSkill, intent_handler
 
 
 class {class_name}(MycroftSkill):
     def __init__(self):
         MycroftSkill.__init__(self)
 
-    @intent_file_handler('{intent_name}.intent')
+    @intent_handler('{intent_name}.intent')
     def handle_{handler_name}(self, message):
 {handler_code}
 


### PR DESCRIPTION
The `intent_file_handler` decorator has been deprecated for some time. 
`intent_handler` now provides the functionality of both handlers.

This replaces the use of the decorator for Skills created with MSK, reducing confusion for new Skill devs.