### PR TITLE
Strip token

### DIFF
--- a/msk/util.py
+++ b/msk/util.py
@@ -37,9 +37,8 @@ from msk import __version__
 from msk.exceptions import PRModified, MskException, SkillNameTaken
 
 ASKPASS = '''#!/usr/bin/env python3
-import sys
-print(r"""{token}"""
-)'''
+print(r"""{token}""")
+'''
 
 skills_kit_footer = '<sub>Created with [mycroft-skills-kit]({}) v{}</sub>' \
                     .format('https://github.com/mycroftai/mycroft-skills-kit',

--- a/msk/util.py
+++ b/msk/util.py
@@ -55,7 +55,7 @@ def register_git_injector(token):
 
     with os.fdopen(fd, 'w') as f:
         f.write(ASKPASS.format(
-            token=token.replace('"""', r'\"\"\"')
+            token=token.replace('"""', r'\"\"\"').strip()
         ))
 
     chmod(tmp_path, 0o700)


### PR DESCRIPTION
This strips any extra whitespace from the token before passing to the git askpass script, This is mainly a quality of life thing since when copying the token an extra space is easily included and hard to see after pasting. The Github module seem to handle this internally so the repo is currently created when a space is included but the push action will fail causing some confusion.

It also removes the `import sys` from the ASKPASS since it's not used when just returning the token.

Should resolve #49 if I'm correct about this.