### PR TITLE
Lock version to supported msm-version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     version='0.3.16',  # Also update in msk/__init__.py
     packages=['msk', 'msk.actions'],
     package_data={'msk': ['licenses/*']},
-    install_requires=['GitPython>=3.0.5', 'msm>=0.5.13', 'pygithub',
+    install_requires=['GitPython>=3.0.5', 'msm~=0.8.9', 'pygithub',
                       'requests', 'colorama'],
     url='https://github.com/MycroftAI/mycroft-skills-kit',
     license='Apache-2.0',


### PR DESCRIPTION
#### Description
This is a quick fix for #59 msk should be updated accordingly but as the 0.9 version of msm hasn't been adopted quite yet I believe this is the best way to keep it synched with mycroft-core and the msm tool in use.

#### Type of PR
- [ x ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Check that a fresh install in a venv works out of the box by running (from the msk folder)

```
python3 -m venv venv
source venv/bin/activate
pip install .
msk create
```

and doesn't throw a TypeError
