### PR TITLE
Support XDG Base Directory compatible MSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ pip3 install msk
 
 ```bash
 msk create
-msk create-test /opt/mycroft/skills/myskill
-msk submit /opt/mycroft/skills/myskill
+msk create-test ~/.local/share/mycroft/skills/myskill
+msk submit ~/.local/share/mycroft/skills/myskill
 ```
+
+Note that Mycroft is [compatible with the XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/basedir/basedir-spec-latest.html) meaning that if you have set `$XDG_DATA_HOME`, you should replace `~/.local/share` for `$XDG_DATA_HOME`.
+
 ### Creating a New Skill
 
 `msk create`:
@@ -37,19 +40,19 @@ msk submit /opt/mycroft/skills/myskill
 
 ### Creating Tests
 
-`msk create-test /opt/mycroft/skills/myskill`:
+`msk create-test ~/.local/share/mycroft/skills/myskill`:
 
 [![msk-create-test](https://images2.imgbox.com/9c/c8/gLRS7xuL_o.gif)](https://asciinema.org/a/Ayzaj6QJbKGBfs2eIQWr11idH?speed=1.5)
 
 ## Submitting a new skill / Updating existing skill
 
-`msk submit /opt/mycroft/skills/myskill`:
+`msk submit ~/.local/share/mycroft/skills/myskill`:
 
 [![msk-submit](https://images2.imgbox.com/7a/5f/RcBxgLXc_o.gif)](https://asciinema.org/a/242108)
 
  --or--
 
 ```bash
-cd /opt/mycroft/skills/myskill
+cd ~/.local/share/mycroft/skills/myskill
 msk submit .
 ```

--- a/msk/__init__.py
+++ b/msk/__init__.py
@@ -15,4 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.3.17rc1"  # Also update in setup.py
+__version__ = "0.4.0"  # Also update in setup.py

--- a/msk/__main__.py
+++ b/msk/__main__.py
@@ -46,9 +46,6 @@ def main():
     parser.add_argument(
         "-s", "--skills-dir", help="Directory to look for skills in"
     )
-    parser.add_argument(
-        "-c", "--repo-cache", help="Location to store local skills repo clone"
-    )
 
     subparsers = parser.add_subparsers(dest="action")
     subparsers.required = True
@@ -65,7 +62,7 @@ def main():
     context.msm = MycroftSkillsManager(
         skills_dir=args.skills_dir,
         repo=SkillRepo(
-            url=args.repo_url, branch=args.repo_branch, path=args.repo_cache
+            url=args.repo_url, branch=args.repo_branch
         ),
     )
     context.branch = context.msm.repo.branch

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     version='0.3.17rc1',  # Also update in msk/__init__.py
     packages=['msk', 'msk.actions'],
     package_data={'msk': ['licenses/*']},
-    install_requires=['GitPython>=3.0.5', 'msm~=0.8.9', 'pygithub',
+    install_requires=['GitPython>=3.0.5', 'msm~=0.9.0', 'pygithub',
                       'requests', 'colorama'],
     url='https://github.com/MycroftAI/mycroft-skills-kit',
     license='Apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='msk',
-    version='0.3.17rc1',  # Also update in msk/__init__.py
+    version='0.4.0',  # Also update in msk/__init__.py
     packages=['msk', 'msk.actions'],
     package_data={'msk': ['licenses/*']},
     install_requires=['GitPython>=3.0.5', 'msm~=0.9.0', 'pygithub',
@@ -35,8 +35,6 @@ setup(
     license='Apache-2.0',
     author='Mycroft AI',
     author_email='support@mycroft.ai',
-    maintainer='Matthew Scholefield',
-    maintainer_email='matthew331199@gmail.com',
     description='Mycroft Skills Kit',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Description
The SkillRepo object from MSM has changed and does not need a provided
path anymore, this adapts to that.

Resolves #62.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Execute `msk create` with this PR and MSM 0.9.0 installed and see if it has created the new skill in `~/.local/share/mycroft/skills` rather than `/opt/mycroft/skills`.